### PR TITLE
Pin nokogiri version to fix latest rbvmomi not working

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ source "http://rubygems.org"
 group :development do
   gem "net-ssh"
   gem "net-scp"
+  gem "nokogiri", "1.5.5"
   gem "rbvmomi"
   gem "alchemist"
   gem "rspec", ">= 0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,7 @@ DEPENDENCIES
   jeweler
   net-scp
   net-ssh
+  nokogiri (= 1.5.5)
   rbvmomi
   rspec
   simplecov

--- a/esx.gemspec
+++ b/esx.gemspec
@@ -54,6 +54,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<jeweler>, [">= 0"])
       s.add_development_dependency(%q<simplecov>, [">= 0"])
       s.add_runtime_dependency(%q<alchemist>, [">= 0"])
+      s.add_runtime_dependency(%q<nokogiri>, ["1.5.5"])
       s.add_runtime_dependency(%q<rbvmomi>, [">= 0"])
       s.add_runtime_dependency(%q<terminal-table>, [">= 0"])
       s.add_runtime_dependency(%q<net-ssh>, [">= 0"])


### PR DESCRIPTION
This is a temporary workaround until rbvmomi is fixed. See https://github.com/vmware/rbvmomi/issues/31 for more details.
