### PR TITLE
Allow specifying hardware versions using create_vm

### DIFF
--- a/lib/esx.rb
+++ b/lib/esx.rb
@@ -116,6 +116,7 @@ module ESX
     #   :datastore => datastore1 #(string, optional)
     #   :disk_file => path to vmdk inside datastore (optional)
     #   :disk_type => flat, sparse (default flat)
+	#   :hw_version => 8 #(int, optional)
     # }
     #
     # supported guest_id list:
@@ -127,6 +128,7 @@ module ESX
       spec[:cpus] = (specification[:cpus] || 1).to_i
       spec[:cpu_cores] = (specification[:cpu_cores] || 1).to_i
       spec[:guest_id] = specification[:guest_id] || 'otherGuest'
+	  spec[:hw_version] = (specification[:hw_version] || 8).to_i
       if specification[:disk_size]
         spec[:disk_size] = (specification[:disk_size].to_i * 1024)
       else
@@ -154,6 +156,7 @@ module ESX
                              :sharedBus => :noSharing)
           }
         ],
+		:version => 'vmx-'+spec[:hw_version].to_s.rjust(2,'0'),
         :extraConfig => [
           {
             :key => 'bios.bootOrder',


### PR DESCRIPTION
When creating new machines on ESXi 5.5, the hardware version of VMs is automatically set to the highest possible, making it version 10. That means it cannot be modified with a normal vSphere client but with a vSphere web client (requiring vCenter obviously) or Workstation 10. By defining it when the VM is created, one can set it manually thus allowing changing settings of the virtual machine via normal vSphere client.
