### PR TITLE
use datastore option in default templates-path

### DIFF
--- a/bin/esx
+++ b/bin/esx
@@ -301,7 +301,7 @@ class CreateVMCommand < BaseCommand
 
   def execute
     begin
-      host = ESX::Host.connect address, user, password, true, {:free_license=>free_license?}
+      host = ESX::Host.connect address, user, password, true, {:free_license => free_license?, :datastore => datastore}
     rescue Exception => e
       $stderr.puts "Can't connect to the host #{address}."
       if debug?

--- a/lib/esx.rb
+++ b/lib/esx.rb
@@ -29,7 +29,7 @@ module ESX
       @address = address
       @password = password
       @user = user
-      @templates_dir = opts[:templates_dir] || "/vmfs/volumes/#{opts[:datastore]}/esx-gem/templates"
+      @templates_dir = opts[:templates_dir] || "/vmfs/volumes/#{opts[:datastore] || "datastore1"}/esx-gem/templates"
       @free_license = opts[:free_license] || false
       if @free_license and !@user.eql?"root"
         raise Exception.new("Can't use Free License mode with user #{@user}. Please use 'root' user.")

--- a/lib/esx.rb
+++ b/lib/esx.rb
@@ -29,7 +29,7 @@ module ESX
       @address = address
       @password = password
       @user = user
-      @templates_dir = opts[:templates_dir] || "/vmfs/volumes/datastore1/esx-gem/templates"
+      @templates_dir = opts[:templates_dir] || "/vmfs/volumes/#{opts[:datastore]}/esx-gem/templates"
       @free_license = opts[:free_license] || false
       if @free_license and !@user.eql?"root"
         raise Exception.new("Can't use Free License mode with user #{@user}. Please use 'root' user.")


### PR DESCRIPTION
Currently the `templates_dir` options default is hardcoded to `/vmfs/volumes/datastore1/esx-gem/templates` even if custom datastore name is passed. This PR changes the default to use the value from `--datastore` option on `create-vm` command.
